### PR TITLE
Refactored search and fixed edit not updating storage

### DIFF
--- a/src/main/java/parser/Parser.java
+++ b/src/main/java/parser/Parser.java
@@ -89,6 +89,7 @@ public class Parser {
                 } catch (Exception e) {
                     throw new InvalidCommand("Format invalid, try again! (edit [attribute] [id] [value])");
                 }
+                storage.saveTransactions(transactions.getTransactions());
                 break;
             case COMMAND_DELETE:
                 index = Integer.parseInt(parts[1]);

--- a/src/main/java/seedu/duke/TransactionManager.java
+++ b/src/main/java/seedu/duke/TransactionManager.java
@@ -100,9 +100,6 @@ public class TransactionManager {
                     }
                 }
             }
-            if (printTransactions.isEmpty()) {
-                throw new NullException("Transaction is invalid");
-            }
             return printTransactions;
         } catch (Exception e) {
             System.out.println(e.getMessage());

--- a/src/main/java/ui/Ui.java
+++ b/src/main/java/ui/Ui.java
@@ -124,6 +124,11 @@ public class Ui {
 
     public void printTransactions(ArrayList<Transaction> transactions) {
         showLine();
+        if (transactions.isEmpty()) {
+            System.out.println("No transaction found.");
+            showLine();
+            return;
+        }
         System.out.println("Here is the list of transactions:");
         for (Transaction transaction : transactions) {
             printTransaction(transaction);


### PR DESCRIPTION
refactor: Delegated empty transaction list handling to printTransactions from searchTransactionList

fix: Storage now updates when an edit is made to a transaction