### PR TITLE
Add SavingMode subsystem with persistent saving goals and float support

### DIFF
--- a/data/goal.csv
+++ b/data/goal.csv
@@ -1,0 +1,1 @@
+girlfriend,1000.123000,Fly us to China,198.893400,false

--- a/src/main/java/seedu/duke/Duke.java
+++ b/src/main/java/seedu/duke/Duke.java
@@ -12,16 +12,16 @@ public class Duke {
 
     public Duke() {
         ui = new Ui();
-        goal = new FinancialGoal();
         storage = new Storage();
-        // load data
         transactions = new TransactionManager();
+        goal = storage.loadGoal();
 
         assert ui != null : "UI should be initialized";
         assert goal != null : "FinancialGoal should be initialized";
         assert storage != null : "Storage should be initialized";
         assert transactions != null : "TransactionManager should be initialized";
     }
+
 
     public void run() {
         ui.printWelcomeMessage();

--- a/src/main/java/seedu/duke/FinancialGoal.java
+++ b/src/main/java/seedu/duke/FinancialGoal.java
@@ -102,7 +102,7 @@ public class FinancialGoal {
 
     // Saving methods
 
-    public void addToSavings(int amount) {
+    public void addToSavings(double amount) {
         isBlank = false;
         deposits += amount;
         checkGoalStatus();
@@ -171,4 +171,12 @@ public class FinancialGoal {
                 + getBalance() + " / $" + targetAmount + " saved \n"
                 + (isAchieved ? "Goal Reached!" : "Keep saving!");
     }
+    public void forceSetDeposits(double deposits) {
+        this.deposits = deposits;
+    }
+
+    public void forceSetAchieved(boolean isAchieved) {
+        this.isAchieved = isAchieved;
+    }
+
 }

--- a/src/main/java/seedu/duke/SavingMode.java
+++ b/src/main/java/seedu/duke/SavingMode.java
@@ -1,7 +1,6 @@
 package seedu.duke;
 
 import ui.Ui;
-
 import java.util.Scanner;
 
 public class SavingMode {
@@ -25,15 +24,14 @@ public class SavingMode {
             }
 
             try {
-                parseSavingCommand(input, ui, goal);
-                // Optionally persist saving state here
+                parseSavingCommand(input, ui, goal, storage);
             } catch (Exception e) {
                 ui.showError(e.getMessage());
             }
         }
     }
 
-    private static void parseSavingCommand(String input, Ui ui, FinancialGoal goal) throws Exception {
+    private static void parseSavingCommand(String input, Ui ui, FinancialGoal goal, Storage storage) throws Exception {
         if (input.isBlank()) {
             return;
         }
@@ -48,6 +46,7 @@ public class SavingMode {
 
             case "set":
                 goal.createNewGoal(ui);
+                storage.saveGoal(goal);  // 保存新设置的目标
                 break;
 
             case "list":
@@ -56,11 +55,11 @@ public class SavingMode {
 
             case "contribute":
             case "save":  // alias
-                handleAddToSavings(parts, goal);
+                handleAddToSavings(parts, goal, storage);
                 break;
 
             case "deduct":
-                handleSubtractFromSavings(parts, goal);
+                handleSubtractFromSavings(parts, goal, storage);
                 break;
 
             default:
@@ -68,19 +67,20 @@ public class SavingMode {
         }
     }
 
-    private static void handleAddToSavings(String[] parts, FinancialGoal goal) throws Exception {
+    private static void handleAddToSavings(String[] parts, FinancialGoal goal, Storage storage) throws Exception {
         if (parts.length < 2 || !parts[1].startsWith("a/")) {
             throw new Exception("Usage: contribute a/AMOUNT");
         }
-        int addAmount = Integer.parseInt(parts[1].substring(2).trim());
+        double addAmount = Double.parseDouble(parts[1].substring(2).trim());
         if (addAmount <= 0) {
             throw new Exception("Amount must be a positive number.");
         }
         goal.addToSavings(addAmount);
-        System.out.println("✅ You have added $" + addAmount + " to your savings goal.");
+        System.out.printf("✅ You have added $%.2f to your savings goal.%n", addAmount);
+        storage.saveGoal(goal);
     }
 
-    private static void handleSubtractFromSavings(String[] parts, FinancialGoal goal) throws Exception {
+    private static void handleSubtractFromSavings(String[] parts, FinancialGoal goal, Storage storage) throws Exception {
         if (parts.length < 2 || !parts[1].startsWith("a/")) {
             throw new Exception("Usage: deduct a/AMOUNT");
         }
@@ -89,7 +89,10 @@ public class SavingMode {
             throw new Exception("Amount must be a positive number.");
         }
         goal.subFromSavings(subAmount);
+        System.out.printf("✅ You have deducted $%.2f from your savings.%n", subAmount);
+        storage.saveGoal(goal);
     }
+
 
     private static void printHelp(Ui ui) {
         ui.showLine();

--- a/src/main/java/seedu/duke/Storage.java
+++ b/src/main/java/seedu/duke/Storage.java
@@ -15,26 +15,25 @@ import enumStructure.Priority;
 import enumStructure.Status;
 
 public class Storage {
-    private static final String FOLDER_PATH = "data";  // Folder path
-    private static final String FILE_PATH = FOLDER_PATH + "/transactions.csv";  // File path
+    private static final String FOLDER_PATH = "data";
+    private static final String FILE_PATH = FOLDER_PATH + "/transactions.csv";
+    private static final String GOAL_FILE_PATH = FOLDER_PATH + "/goal.csv";
 
-    // Check and create the folder if it doesn't exist
     private void createDataFolderIfNeeded() {
         File folder = new File(FOLDER_PATH);
         if (!folder.exists()) {
-            folder.mkdirs();  // Create the folder
+            folder.mkdirs();
         }
     }
 
-    // Save the transaction data to a CSV file
     public void saveTransactions(ArrayList<Transaction> transactions) {
-        assert transactions != null : "Transaction list should not be null";
+        assert transactions != null;
 
-        createDataFolderIfNeeded();  // Ensure the folder exists
+        createDataFolderIfNeeded();
 
         try (BufferedWriter writer = new BufferedWriter(new FileWriter(FILE_PATH))) {
             for (Transaction t : transactions) {
-                assert t != null : "Transaction object should not be null";
+                assert t != null;
                 writer.write(formatTransaction(t));
                 writer.newLine();
             }
@@ -43,52 +42,42 @@ public class Storage {
         }
     }
 
-    // Load transaction data from the CSV file
     public ArrayList<Transaction> loadTransactions() {
         ArrayList<Transaction> transactions = new ArrayList<>();
         File file = new File(FILE_PATH);
 
         if (!file.exists()) {
-            return transactions; // Return an empty list if the file doesn't exist
+            return transactions;
         }
 
         try (BufferedReader reader = new BufferedReader(new FileReader(file))) {
             String line;
             while ((line = reader.readLine()) != null) {
-                assert !line.trim().isEmpty() : "CSV line should not be empty";
-                Transaction t = parseTransaction(line);
-                if (t != null) {
-                    transactions.add(t);
+                if (!line.trim().isEmpty()) {
+                    Transaction t = parseTransaction(line);
+                    if (t != null) {
+                        transactions.add(t);
+                    }
                 }
             }
         } catch (IOException e) {
             System.out.println("Error loading transactions: " + e.getMessage());
         }
+
         return transactions;
     }
 
-    // Convert a Transaction object into a CSV format string
     private String formatTransaction(Transaction t) {
-        assert t != null : "Transaction cannot be null";
-        assert t.getCurrency() != null : "Currency cannot be null";
-        assert t.getCategory() != null : "Category cannot be null";
-        assert t.getDate() != null : "Date cannot be null";
-        assert t.getStatus() != null : "Status cannot be null";
-        assert t.getPriority() != null : "Priority cannot be null";
-        assert t.getDescription() != null : "Description cannot be null";
-
         return String.format("%d,%s,%f,%s,%s,%s,%s,%d,%b,%b,%s",
                 t.getId(), t.getDescription(), t.getAmount(), t.getCurrency(),
                 t.getCategory(), t.getDate(), t.getStatus(),
                 t.getRecurringPeriod(), t.isDeleted(), t.isCompleted(), t.getPriority());
     }
 
-    // Parse a CSV line into a Transaction object
     private Transaction parseTransaction(String line) {
         try {
-            assert line != null : "CSV line should not be null";
             String[] parts = line.split(",");
-            assert parts.length == 11 : "Expected 11 fields but got " + parts.length;
+            if (parts.length != 11) return null;
 
             int id = Integer.parseInt(parts[0]);
             String description = parts[1];
@@ -102,29 +91,63 @@ public class Storage {
             boolean isCompleted = Boolean.parseBoolean(parts[9]);
             Priority priority = Priority.valueOf(parts[10].toUpperCase());
 
-            assert amount >= 0 : "Amount should be non-negative";
-            assert currency != null : "Currency should not be null";
-            assert category != null : "Category should not be null";
-            assert date != null : "Date should not be null";
-            assert status != null : "Status should not be null";
-
             Transaction transaction = new Transaction(id, description, amount, currency, category, date, status);
             transaction.setRecurringPeriod(recurringPeriod);
             transaction.setPriority(priority);
-
-            if (isDeleted) {
-                transaction.delete();
-            }
-            if (isCompleted) {
-                transaction.complete();
-            }
+            if (isDeleted) transaction.delete();
+            if (isCompleted) transaction.complete();
             return transaction;
         } catch (Exception e) {
             System.out.println("Error parsing transaction: " + line + " - " + e.getMessage());
             return null;
         }
     }
+
+    // ✅ Saving FinancialGoal to goal.csv
+    public void saveGoal(FinancialGoal goal) {
+        createDataFolderIfNeeded();
+        try (BufferedWriter writer = new BufferedWriter(new FileWriter(GOAL_FILE_PATH))) {
+            writer.write(formatGoal(goal));
+            writer.newLine();
+        } catch (IOException e) {
+            System.out.println("Error saving financial goal: " + e.getMessage());
+        }
+    }
+
+    private String formatGoal(FinancialGoal goal) {
+        return String.format("%s,%f,%s,%f,%b",
+                goal.getGoal(),
+                goal.getTargetAmount(),
+                goal.getDescription().replace(",", " "),
+                goal.getBalance(),
+                goal.isAchieved());
+    }
+
+    public FinancialGoal loadGoal() {
+        File file = new File(GOAL_FILE_PATH);
+        if (!file.exists()) {
+            return new FinancialGoal();
+        }
+
+        try (BufferedReader reader = new BufferedReader(new FileReader(file))) {
+            String line = reader.readLine();
+            if (line != null) {
+                String[] parts = line.split(",", 5);
+                String name = parts[0];
+                double target = Double.parseDouble(parts[1]);
+                String description = parts[2];
+                double deposits = Double.parseDouble(parts[3]);
+                boolean isAchieved = Boolean.parseBoolean(parts[4]);
+
+                FinancialGoal goal = new FinancialGoal(name, target, description);
+                goal.forceSetDeposits(deposits);
+                goal.forceSetAchieved(isAchieved);
+                return goal;
+            }
+        } catch (Exception e) {
+            System.out.println("Error loading financial goal: " + e.getMessage());
+        }
+
+        return new FinancialGoal();
+    }
 }
-
-
-


### PR DESCRIPTION
## Summary

This PR introduces a new interactive `SavingMode` subsystem that allows users to set saving goals, contribute, deduct, and monitor progress in a separate mode. Data is persisted to a `goal.csv` file for continuity across application restarts.

## Features

- [x] Enter SavingMode via `saving` command
- [x] `set`: interactively set a new financial goal
- [x] `list`: view current saving goal status
- [x] `contribute a/AMOUNT`: add money to savings
- [x] `deduct a/AMOUNT`: subtract money from savings
- [x] Supports `double` (floating-point) input
- [x] All savings are saved to `data/goal.csv`
- [x] Input validations (e.g., negative number checks, malformed input)
- [x] Helpful UI messages and command help within SavingMode

## Example Commands

```shell
saving
set
list
contribute a/350.75
deduct a/20.00
exit
